### PR TITLE
chore(ubuntubox): Add apt update before installing dependencies

### DIFF
--- a/ubuntubox/Containerfile
+++ b/ubuntubox/Containerfile
@@ -1,7 +1,8 @@
 FROM ghcr.io/hedlund/ubuntu:latest
 
 # Install extra packages
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN sudo apt update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
   ack \
   apt-transport-https \
   ca-certificates \


### PR DESCRIPTION
Make the weekly Docker builds a bit less flaky.
